### PR TITLE
Setup Maven project and fix bug with furnaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>misterymob475</groupId>
+    <artifactId>LotrModConverter</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+
+   <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+       <repository>
+           <id>frostalf-repo</id>
+           <url>https://repo.frostalf.net</url>
+       </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.piegamesde</groupId>
+            <artifactId>nbt</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <!-- use UTF-8 for everything -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <archive>
+                        <manifest>
+                            <mainClass>misterymob475.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/misterymob475/Fixers.java
+++ b/src/misterymob475/Fixers.java
@@ -1501,8 +1501,8 @@ public class Fixers {
         } else map.put("BurnTime", new IntTag("BurnTime", 0));
         Optional<Tag<?>> OSmeltTime = Util.getAsTagIfExists(map, TagType.TAG_SHORT, "SmeltTime");
         if (OSmeltTime.isPresent()) {
-            map.replace("SmeltTime", new IntTag("CookTime", ((IntTag) OSmeltTime.get()).getValue()));
-            map.put(new IntTag("CookTimeTotal", ((IntTag) OSmeltTime.get()).getValue()));
+            map.replace("SmeltTime", new IntTag("CookTime", ((Short) OSmeltTime.get().getValue()).intValue()));
+            map.put(new IntTag("CookTimeTotal", ((Short) OSmeltTime.get().getValue()).intValue()));
         } else {
             map.put(new IntTag("CookTime", 0));
             map.put(new IntTag("CookTimeTotal", 0));


### PR DESCRIPTION
The Maven project should be fully setup with both dependencies. In order to build the jar simply run maven package. The jar includes all required dependencies and is fully executable since the Main file is specified.

I also fixed a bug that seemed to occur when furnaces that were in the middle of cooking an item were converted. This seemed to be caused by the ShortTags being cast to IntTags which seems to be because shorts cannot be cast to ints.