### PR TITLE
Fix minecraft:coal_block

### DIFF
--- a/Conversions.json
+++ b/Conversions.json
@@ -42147,7 +42147,7 @@
       "lotr:bree_crafting_table"
     ],
     "minecraft:coal_block": [
-      ""
+      "minecraft:coal_block"
     ],
     "lotr:item.hoeRivendell": [
       "lotr:rivendell_hoe"


### PR DESCRIPTION
Coal Blocks from vanilla did not seem to be getting converted. This PR corrects the mapping and they should now be converted correctly.